### PR TITLE
add CSRF token support for OpenRefine 3.3 onwards

### DIFF
--- a/src/Keboola/OpenRefine/Client.php
+++ b/src/Keboola/OpenRefine/Client.php
@@ -22,6 +22,25 @@ class Client
     protected $temp;
 
     /**
+     * the CSRF token
+     *
+     * @var string
+     */
+    protected $csrfToken;
+
+    /**
+     * OpenRefine server version
+     *
+     * @var null|string
+     */
+    static private $version = null;
+
+    /**
+     * Minimum version of OpenRefine for which the CSRF token must be used
+     */
+    const MIN_VERSION_FOR_CSRF = '3.3';
+
+    /**
      * Client constructor.
      *
      * @param string $host
@@ -46,8 +65,7 @@ class Client
         }
 
         try {
-            $response = $this->client->request(
-                "POST",
+            $response = $this->post(
                 "create-project-from-upload",
                 [
                     "multipart" => [
@@ -87,8 +105,7 @@ class Client
     public function applyOperations(string $projectId, array $operations): void
     {
         try {
-            $response = $this->client->request(
-                "POST",
+            $response = $this->post(
                 "apply-operations",
                 [
                     "form_params" => [
@@ -116,7 +133,7 @@ class Client
 
     public function exportRowsToCsv(string $projectId): CsvFile
     {
-        $response = $this->client->request("POST", "export-rows", [
+        $response = $this->post("export-rows", [
             "form_params" => [
                 "project" => $projectId,
                 "format" => "csv",
@@ -157,7 +174,7 @@ class Client
 
     public function deleteProject(string $projectId): void
     {
-        $response = $this->client->request("POST", "delete-project", [
+        $response = $this->post("delete-project", [
             "form_params" => [
                 "project" => $projectId,
             ],
@@ -196,5 +213,104 @@ class Client
         if (isset($decodedResponse["code"])) {
             return $decodedResponse["code"];
         }
+    }
+
+    /**
+     * Sets the OpenRefine version calling the get-version endpoint
+     *
+     * @return void
+     */
+    private function setVersion(): void
+    {
+        if (is_null(self::$version)) {
+            self::$version = "0.0";
+            $response = $this->client->request("GET", "get-version");
+            if (!$this->isResponseError($response)) {
+                $decodedResponse = json_decode($response->getBody()->__toString(), true);
+                if (array_key_exists("version", $decodedResponse)) {
+                    self::$version = $decodedResponse["version"];
+                }
+            }
+        }
+    }
+
+    /**
+     * Gets the OpenRefine version
+     *
+     * @return string
+     */
+    protected function getVersion(): string
+    {
+        if (is_null(self::$version)) $this->setVersion();
+        return self::$version;
+    }
+
+    /**
+     * Gets the CSRF token
+     *
+     * @return string
+     */
+    protected function getCsrfToken(): string
+    {
+        try {
+            $this->setCsrfToken();
+        } catch (Exception $e) {
+            $this->csrfToken = "";
+        }
+        return $this->csrfToken;
+    }
+
+    /**
+     * Sets the CSRF token calling the get-csrf-token endpoint
+     *
+     * @return void
+     */
+    protected function setCsrfToken(): void
+    {
+        $token = "";
+        $error = false;
+        if (is_null($this->csrfToken) && version_compare(self::getVersion(), self::MIN_VERSION_FOR_CSRF, '>=')) {
+            $response = $this->client->request("GET", "get-csrf-token");
+            if (!$this->isResponseError($response)) {
+                $decodedResponse = json_decode($response->getBody()->__toString(), true);
+                if (array_key_exists("token", $decodedResponse)) $token = $decodedResponse["token"];
+                else $error = true;
+            } else $error = true;
+        }
+        if ($error) {
+            throw new Exception("Cannot GET the CSRF token");
+        }
+        $this->csrfToken = $token;
+    }
+
+    /**
+     * Does the post request using the client and setting the CSRF token if needed
+     *
+     * @param string $endpoint
+     * @param array $params
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    protected function post(string $endpoint, array $params = []): \Psr\Http\Message\ResponseInterface
+    {
+        if (version_compare(self::getVersion(), self::MIN_VERSION_FOR_CSRF, '>=')) {
+            $this->csrfToken = $this->getCsrfToken();
+            if ($this->csrfToken !== "") {
+                if (stristr($endpoint,"create") !== false) {
+                    $endpoint .= '?csrf_token='.$this->csrfToken;
+                } else if (array_key_exists('multipart', $params)) {
+                    array_push($params['multipart'],[
+                        'name' => "csrf_token",
+                        'contents' => $this->csrfToken
+                    ]);
+                } else if (array_key_exists('form_params', $params)) {
+                    $params['form_params']['csrf_token'] = $this->csrfToken;
+                } else {
+                    $params["csrf_token"] = $this->csrfToken;
+                }
+            }
+            // The CSRF token is a one timer, forget it to get a new one
+            $this->csrfToken = null;
+        }
+        return $this->client->request("POST", $endpoint, $params);
     }
 }


### PR DESCRIPTION
Hello there,
this PR adds support for the Cross-Site Request Forgery (CSRF) protection to API commands which use the POST method introduced in v3.3 of OpenRefine.

See https://github.com/OpenRefine/OpenRefine/wiki/Changes-for-3.3#csrf-protection-changes

Please feel free to merge at your convenience,
cheers!

 Giorgio